### PR TITLE
No arch parameters needed, the compiler and linker use the arch of the controlling terminal

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -19,9 +19,9 @@ C_SRC_OUTPUT ?= $(CURDIR)/../priv/serctl.so
 UNAME_SYS := $(shell uname -s)
 ifeq ($(UNAME_SYS), Darwin)
 	CC ?= cc
-	CFLAGS ?= -O3 -std=gnu99 -arch x86_64 -finline-functions -Wall -Wmissing-prototypes
-	CXXFLAGS ?= -O3 -arch x86_64 -finline-functions -Wall
-	LDFLAGS ?= -arch x86_64 -flat_namespace -undefined suppress
+	CFLAGS ?= -O3 -std=gnu99 -finline-functions -Wall -Wmissing-prototypes
+	CXXFLAGS ?= -O3 -finline-functions -Wall
+	LDFLAGS ?= -flat_namespace -undefined suppress
 else ifeq ($(UNAME_SYS), FreeBSD)
 	CC ?= cc
 	CFLAGS ?= -O3 -std=gnu99 -finline-functions -Wall -Wmissing-prototypes


### PR DESCRIPTION


Removing the arch from the compile flags lets the compiler pick the architecture. Which is usually what people expect.