### PR TITLE
Add access to tcflush

### DIFF
--- a/c_src/serctl.c
+++ b/c_src/serctl.c
@@ -233,6 +233,28 @@ static ERL_NIF_TERM nif_tcsetattr(ErlNifEnv *env, int argc,
   return atom_ok;
 }
 
+static ERL_NIF_TERM nif_tcflush(ErlNifEnv *env, int argc,
+                                const ERL_NIF_TERM argv[]) {
+  SRLY_STATE *sp = NULL;
+  ErlNifBinary buf = {0};
+  int queue_selector = 0;
+
+  int err = 0;
+
+  if (!enif_get_resource(env, argv[0], SRLY_STATE_RESOURCE, (void **)&sp))
+    return enif_make_badarg(env);
+
+  if (!enif_get_int(env, argv[1], &queue_selector))
+    return enif_make_badarg(env);
+
+  if (tcflush(sp->fd, queue_selector) < 0) {
+    err = errno;
+    return error_tuple(env, err);
+  }
+
+  return atom_ok;
+}
+
 static ERL_NIF_TERM nif_cfsetispeed(ErlNifEnv *env, int argc,
                                     const ERL_NIF_TERM argv[]) {
   ErlNifBinary buf = {0};
@@ -364,6 +386,7 @@ static ErlNifFunc nif_funcs[] = {{"open_nif", 1, nif_open},
                                  {"write_nif", 2, nif_write},
                                  {"tcgetattr", 1, nif_tcgetattr},
                                  {"tcsetattr_nif", 3, nif_tcsetattr},
+                                 {"tcflush_nif", 2, nif_tcflush},
                                  {"cfsetispeed_nif", 2, nif_cfsetispeed},
                                  {"cfsetospeed_nif", 2, nif_cfsetospeed},
 

--- a/src/serctl.erl
+++ b/src/serctl.erl
@@ -42,6 +42,7 @@
 
     tcgetattr/1,
     tcsetattr/3,
+    tcflush/2,
 
     cfsetispeed/2,
     cfsetospeed/2,
@@ -185,6 +186,21 @@ tcsetattr(FD, Action, Termios) ->
     tcsetattr_nif(FD, Action, Termios).
 
 tcsetattr_nif(_, _, _) ->
+    erlang:nif_error(not_implemented).
+
+% @doc discards data written but not transmitted or recieved but not read
+%
+% The second argument determines whether to flush input, output, or both
+-spec tcflush(fd(), atom()) -> 'ok' | errno() | {'error', 'unsupported'}.
+tcflush(FD, Discard) when is_atom(Discard) ->
+    case constant(Discard) of
+        undefined ->
+            {error, unsupported};
+        N ->
+            tcflush_nif(FD, N)
+    end.
+
+tcflush_nif(_, _) ->
     erlang:nif_error(not_implemented).
 
 % @doc Set the input speed of a serial device


### PR DESCRIPTION
I needed `tcflush` and didn't find it present already. This patch worked for me.

I've only used it as `serctl:tcflush(FD, tcioflush)`